### PR TITLE
fixed certificate problem (connection reset by peer when using wget a…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN \
 
 # fix certificate problem (avoid con reset by peer)
 RUN \
-  apk update && \
   apk add ca-certificates wget && \
   update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN \
   apk update && apk add --no-cache $BUILD_PACKAGES $PACKAGES && \
   npm install -g http-proxy-to-socks
 
+# fix certificate problem (avoid con reset by peer)
+RUN \
+  apk update && \
+  apk add ca-certificates wget && \
+  update-ca-certificates
+
 # install polipo
 RUN \
 	wget https://github.com/jech/polipo/archive/master.zip -O polipo.zip && \


### PR DESCRIPTION
Hi, 
This commit fixes the certificate problem that prevented using wget with github.com.

Here is an extract of the ouput console

```
Step 4/10 : RUN 	wget https://github.com/jech/polipo/archive/master.zip -O polipo.zip && 	unzip polipo.zip &&   cd polipo-master &&   make &&   install polipo /usr/local/bin/ &&   cd .. &&   rm -rf polipo.zip polipo-master &&   mkdir -p /usr/share/polipo/www /var/cache/polipo
 ---> Running in 0e5f8997f687
Connecting to github.com (x.x.x.x:443)
wget: error getting response: Connection reset by peer
```

Now it works.
Have a nice day.