### PR TITLE
Tor instances configurable in run command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,11 @@ RUN	git clone https://github.com/trimstray/multitor && \
 # let haproxy listen from outside, instand only in the docker container
   sed -i s/127.0.0.1:16379/0.0.0.0:16379/g templates/haproxy-template.cfg
 
+COPY startup.sh /multitor/
+RUN chmod +x /multitor/startup.sh
+
 WORKDIR /multitor/
 EXPOSE	16379
 
-CMD multitor --init 5 --user root --socks-port 9000 --control-port 9900 --proxy privoxy --haproxy --verbose --debug > /tmp/multitor.log; tail -f /tmp/multitor.log
+#CMD multitor --init 5 --user root --socks-port 9000 --control-port 9900 --proxy privoxy --haproxy --verbose --debug > /tmp/multitor.log; tail -f /tmp/multitor.log
+CMD ["./startup.sh"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "${TOR_INSTANCES}" ]]; then
+  TOR_INSTANCE_COUNT=5
+  echo "Environment variable TOR_INSTANCES not specified, defaulting to 5"
+else
+  TOR_INSTANCE_COUNT="${TOR_INSTANCES}"
+fi
+
+re='^[0-9]+$'
+if ! [[ $TOR_INSTANCE_COUNT =~ $re ]] ; then
+   echo "error: TOR_INSTANCES is not a number, defaulting to 5"
+   TOR_INSTANCE_COUNT=5
+fi
+
+
+multitor --init $TOR_INSTANCE_COUNT --user root --socks-port 9000 --control-port 9900 --proxy privoxy --haproxy --verbose --debug > /tmp/multitor.log; tail -f /tmp/multitor.log


### PR DESCRIPTION
Can now specify tor instances in run command like so: 
`docker run --rm -e "TOR_INSTANCES=10" jkamsker/multitor`
